### PR TITLE
Create liquid-tag-parser.rb

### DIFF
--- a/lib/liquid-tag-parser.rb
+++ b/lib/liquid-tag-parser.rb
@@ -1,0 +1,5 @@
+# Frozen-string-literal: true
+# Copyright: 2012 - 2018 - MIT License
+# Encoding: utf-8
+
+require_relative "liquid/tag/parser"


### PR DESCRIPTION
- [x] I have not attempted to bump, or alter versions.
- [x] This is a source change.

## Description

Adds `liquid-tag-parser/lib/liquid-tag-parser.rb`.

If gem is included in a Jekyll theme (that includes its own plugin that requires `liquid/tag/parser`) as a runtime dependency in its `.gemspec` file, as via

```
  spec.add_runtime_dependency "liquid-tag-parser", "1.9.0"
```

Jekyll tries to require that gem by name in `require_theme_deps`:

https://github.com/jekyll/jekyll/blob/master/lib/jekyll/plugin_manager.rb#L38-L46

The result is a build-time error. E.g.:

```
$ bundle exec jekyll build --trace --verbose
  Logging at level: debug
Configuration file: none
             Theme: jekyll-theme
      Theme source: /home/ubuntu/.gem/bundler/gems/jekyll-theme-############
         Requiring: liquid-tag-parser
  Dependency Error: Yikes! It looks like you don't have liquid-tag-parser or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full error message from Ruby is: 'cannot load such file -- liquid-tag-parser' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/! 
bundler: failed to load command: jekyll (/usr/local/bin/jekyll)
...
```

Adding `liquid-tag-parser/lib/liquid-tag-parser.rb` seems to fix, unless there's a cleaner way?

Thanks for the handy plugin!